### PR TITLE
Sends email notification to any mentioned owners

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -9,6 +9,10 @@ owner = list(set([
     'paullik-test',
 ]))
 
+owner_email = {
+    'foobarfoo': 'foobar@gmail.com'
+}
+
 # server to connect to
 server = 'chat.freenode.net'
 # server's port
@@ -42,6 +46,12 @@ cmds_list = list(set([
     'so',
     'twitter',
 ]))
+
+# smtp server
+smtp_server = 'smtp.gmail.com'
+smtp_port = 25
+from_email_address = 'changeme@gmail.com'
+from_email_password = 'p@s$w0rd' 
 
 # users should NOT modify below!
 log = os.path.join(os.getcwd(), '..', 'logs', '')

--- a/src/functions.py
+++ b/src/functions.py
@@ -2,6 +2,7 @@ import config
 import err
 import datetime
 import socket
+import smtplib
 
 def get_sender(msg):
     "Returns the user's nick (string) that sent the message"
@@ -314,3 +315,28 @@ def send_response(response, destination, s, logfile):
         return True
 
     return None
+
+def email_alert(component, to_address):
+    status = False
+    sender = component['sender']
+    channel = component['action_args'][0]
+    ircmsg = component['arguments']
+    message = ircmsg[ircmsg.index(' ')+1:]
+    server = smtplib.SMTP(config.smtp_server, config.smtp_port)
+    server.ehlo()
+    server.starttls()
+    server.ehlo()
+    try:
+        server.login(config.from_email_address, config.from_email_password)
+    except smtplib.SMTPAuthenticationError:
+        server.quit()
+
+    msg = ("From: %s\r\nTo: %s\r\n\r\n%s (%s) said:\r\n\r\n%s") % (config.from_email_address, to_address, sender, channel, message)
+
+    try:
+        server.sendmail(config.from_email_address, to_address, msg)
+    except:
+        server.quit()
+
+    server.quit()
+    return status

--- a/src/ircbot.py
+++ b/src/ircbot.py
@@ -45,6 +45,14 @@ def run(socket, channels, cmds, nick, logfile):
                 #get the command issued to the bot without the exclamation mark
                 cmd = components['arguments'][1:pos]
                 response = run_cmd(socket, cmd, components, cmds)
+            elif 'PRIVMSG' == components['action']:
+                first_word = components['arguments'].split()[0]
+                if ':' in first_word:
+                    if first_word[:first_word.index(':')] in config.owner and first_word[:first_word.index(':')] in config.owner_email:
+                        email_alert(components, config.owner_email[first_word[:first_word.index(':')]])
+                else:
+                    if first_word in config.owner and first_word in config.owner_email:
+                        email_alert(components, config.owner_email[first_word])
 
             elif 'KICK' == components['action'] and \
                 nick == components['action_args'][1]:


### PR DESCRIPTION
I idle in a number of IRC channels, and sometimes I'd like to know when I'm mentioned in case of something important, or something that needs my attention. I added in the ability for the bot to sent an email to any owners that have an email specified, whenever they're highlighted in an IRC channel.
